### PR TITLE
Github 아이콘 크기 버그 해결 및 최적화

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,19 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react", "@emotion/babel-preset-css-prop"],
-  "plugins": ["@emotion/babel-plugin"]
+  "presets": [
+    "@babel/preset-env",
+    "@babel/preset-react",
+    "@emotion/babel-preset-css-prop"
+  ],
+  "plugins": [
+    [
+      "@emotion",
+      {
+        // sourceMap is on by default but source maps are dead code eliminated in production
+        "sourceMap": true,
+        "autoLabel": "dev-only",
+        "labelFormat": "[local]",
+        "cssPropOptimization": true
+      }
+    ]
+  ]
 }

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -19,3 +19,7 @@ export const wrapRootElement = ({ element }) => {
 // export const wrapPageElement = ({ element, props }) => {
 //   return <Layout {...props}>{element}</Layout>
 // }
+//SSG에서 Font Awesome 스타일이 head에 추가되는 시점을 조정
+import "@fortawesome/fontawesome-svg-core/styles.css"
+import { config } from "@fortawesome/fontawesome-svg-core"
+config.autoAddCss = false

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,25 +1,36 @@
 import React from "react"
+// normalize with emotion
+import { Global, css } from "@emotion/react"
+import * as normalize from "normalize.css"
+import extraNormalize from "./src/styles/extraNormalize"
 // custom typefaces
 import "@fontsource/montserrat/variable.css"
 import "@fontsource/merriweather"
-// normalize CSS across browsers
-import "./src/normalize.css"
 // custom CSS styles
 import "./src/style.css"
-
 // Highlighting for code blocks
 import "prismjs/themes/prism.css"
 // import Layout from "./src/components/layout"
 import TagProvider from "./src/context/TagProvider"
+//SSG에서 Font Awesome 스타일이 head에 추가되는 시점을 조정
+import "@fortawesome/fontawesome-svg-core/styles.css"
+import { config } from "@fortawesome/fontawesome-svg-core"
+config.autoAddCss = false
 
 export const wrapRootElement = ({ element }) => {
-  return <TagProvider>{element}</TagProvider>
+  return (
+    <>
+      <Global
+        styles={css`
+          ${normalize}
+          ${extraNormalize}
+        `}
+      />
+      <TagProvider>{element}</TagProvider>
+    </>
+  )
 }
 
 // export const wrapPageElement = ({ element, props }) => {
 //   return <Layout {...props}>{element}</Layout>
 // }
-//SSG에서 Font Awesome 스타일이 head에 추가되는 시점을 조정
-import "@fortawesome/fontawesome-svg-core/styles.css"
-import { config } from "@fortawesome/fontawesome-svg-core"
-config.autoAddCss = false

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -57,15 +57,7 @@ module.exports = {
         ],
       },
     },
-    {
-      resolve: `gatsby-plugin-emotion`,
-      options: {
-        sourceMap: true,
-        autoLabel: "dev-only",
-        labelFormat: `[local]`,
-        cssPropOptimization: true,
-      },
-    },
+    `gatsby-plugin-emotion`,
     `gatsby-transformer-sharp`,
     `gatsby-plugin-sharp`,
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "gatsby-source-filesystem": "^5.7.0",
         "gatsby-transformer-remark": "^6.7.0",
         "gatsby-transformer-sharp": "^5.7.0",
+        "normalize.css": "^8.0.1",
         "prismjs": "^1.29.0",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
@@ -15195,6 +15196,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/normalize.css": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
+      "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg=="
     },
     "node_modules/not": {
       "version": "0.1.0",
@@ -31934,6 +31940,11 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
+    },
+    "normalize.css": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
+      "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg=="
     },
     "not": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gatsby-source-filesystem": "^5.7.0",
     "gatsby-transformer-remark": "^6.7.0",
     "gatsby-transformer-sharp": "^5.7.0",
+    "normalize.css": "^8.0.1",
     "prismjs": "^1.29.0",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",

--- a/src/styles/extraNormalize.js
+++ b/src/styles/extraNormalize.js
@@ -1,0 +1,9 @@
+const extraNormalize = `
+  ol, ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+`
+
+export default extraNormalize


### PR DESCRIPTION
Font Awesome 관련 아이콘 크기 문제는 gatsby-browser.js에 설정을 추가해서 해결했습니다.
emotion 공식문서를 참고해 @emotion/babel 설정을 다시 작성했습니다.
normalize.css를 emotion을 이용해 gatsby-browser.js rootWrapElement에 작성했습니다.
추가로 초기화 하고 싶은 스타일은 extraNormalize.js 파일에 추가하고 import 하는 방식으로 추가했습니다.