### PR TITLE
Refact: ContextAPI에서 Redux toolkit으로 리팩토링

### DIFF
--- a/gatsby-browser.tsx
+++ b/gatsby-browser.tsx
@@ -3,8 +3,9 @@ import { config } from '@fortawesome/fontawesome-svg-core';
 import type { GatsbyBrowser } from 'gatsby';
 // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
 import * as React from 'react';
+import { Provider } from 'react-redux';
 
-import TagProvider from './src/context/TagProvider';
+import store from './src/app/store';
 import { globalStyles } from './src/styles/globalStyles';
 import { globalVariables } from './src/styles/globalVariables';
 // custom typefaces
@@ -33,7 +34,7 @@ export const wrapPageElement: GatsbyBrowser['wrapPageElement'] = ({
           ${globalStyles}
         `}
       />
-      <TagProvider>{element}</TagProvider>
+      <Provider store={store}>{element}</Provider>;
     </>
   );
 };

--- a/gatsby-ssr.tsx
+++ b/gatsby-ssr.tsx
@@ -1,14 +1,15 @@
 // const Layout = require("./src/components/layout")
 import type { GatsbySSR } from 'gatsby';
+import { Provider } from 'react-redux';
 
-import TagProvider from './src/context/TagProvider';
+import store from './src/app/store';
 
 export const onRenderBody: GatsbySSR['onRenderBody'] = ({
   setHtmlAttributes
 }) => setHtmlAttributes({ lang: 'en' });
 
 export const wrapRootElement: GatsbySSR['wrapPageElement'] = ({ element }) => {
-  return <TagProvider>{element}</TagProvider>;
+  return <Provider store={store}>{element}</Provider>;
 };
 
 // exports.wrapPageElement = ({ element, props }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@fortawesome/free-regular-svg-icons": "^6.4.0",
         "@fortawesome/free-solid-svg-icons": "^6.4.0",
         "@fortawesome/react-fontawesome": "^0.2.0",
+        "@reduxjs/toolkit": "^1.9.5",
         "gatsby": "^5.11.0",
         "gatsby-plugin-emotion": "^8.11.0",
         "gatsby-plugin-feed": "^5.11.0",
@@ -39,6 +40,7 @@
         "prismjs": "^1.29.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-redux": "^8.1.1",
         "react-transition-group": "^4.4.5"
       },
       "devDependencies": {
@@ -4407,6 +4409,29 @@
         "node": ">=12"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.5.tgz",
+      "integrity": "sha512-Rt97jHmfTeaxL4swLRNPD/zV4OxTes4la07Xc4hetpUW/vc75t5m1ANyxG6ymnEQ2FsLQsoMlYB2vV1sO3m8tQ==",
+      "dependencies": {
+        "immer": "^9.0.21",
+        "redux": "^4.2.1",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.8"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.0.2"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -4632,6 +4657,15 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
@@ -4750,7 +4784,7 @@
       "version": "18.2.6",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.6.tgz",
       "integrity": "sha512-2et4PDvg6PVCyS7fuTc4gPoksV58bW0RwSxWKcPRcHZf0PRUGq03TKcD/rUHe3azfV6/5/biUBJw+HhCQjaP0A==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -4800,6 +4834,11 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@types/yoga-layout": {
       "version": "1.9.2",
@@ -20140,6 +20179,49 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/react-redux": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.1.tgz",
+      "integrity": "sha512-5W0QaKtEhj+3bC0Nj0NkqkhIv8gLADH/2kYFMTHxCVqQILiWzLv6MaLuV5wJU3BQEdHKzTfcvPN0WMS6SC1oyA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4 || ^5.0.0-beta.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-redux/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
     "node_modules/react-refresh": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
@@ -21093,6 +21175,11 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
       "integrity": "sha512-uuoJ1hU/k6M0779t3VMVIYpb2VMJk05cehCaABFhXaibcbvfgR8wKiozLjVFSzJPmQMRqIcO0HMyTFqfV09V6Q=="
+    },
+    "node_modules/reselect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
+      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="
     },
     "node_modules/resolve": {
       "version": "1.22.2",
@@ -23335,6 +23422,14 @@
         "file-loader": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.4.0",
     "@fortawesome/free-solid-svg-icons": "^6.4.0",
     "@fortawesome/react-fontawesome": "^0.2.0",
+    "@reduxjs/toolkit": "^1.9.5",
     "gatsby": "^5.11.0",
     "gatsby-plugin-emotion": "^8.11.0",
     "gatsby-plugin-feed": "^5.11.0",
@@ -37,6 +38,7 @@
     "prismjs": "^1.29.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-redux": "^8.1.1",
     "react-transition-group": "^4.4.5"
   },
   "devDependencies": {

--- a/src/app/rootReducer.ts
+++ b/src/app/rootReducer.ts
@@ -1,0 +1,12 @@
+import { combineReducers } from '@reduxjs/toolkit';
+
+import tagsReducer from '../features/tags/tagsSlice';
+
+const rootReducer = combineReducers({
+  tags: tagsReducer
+  // 다른 리듀서 추가
+});
+
+export type RootState = ReturnType<typeof rootReducer>;
+
+export default rootReducer;

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,0 +1,13 @@
+import { configureStore } from '@reduxjs/toolkit';
+
+import tagsReducer from '../features/tags/tagsSlice';
+
+export const store = configureStore({
+  reducer: {
+    tags: tagsReducer
+  }
+});
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;
+
+export default store;

--- a/src/components/tags.tsx
+++ b/src/components/tags.tsx
@@ -1,9 +1,10 @@
 import { css } from '@emotion/react';
 import { useLocation } from '@reach/router';
 import { Link } from 'gatsby';
-import { useContext } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 
-import TagContext from '../context/TagContext';
+import { RootState } from '../app/store';
+import { selectTag } from '../features/tags/tagsSlice';
 
 const hoverAndSelectedTagStyle = css`
   font-weight: var(--fontWeight-bold);
@@ -32,7 +33,8 @@ type TagProps = {
 };
 
 const Tag = ({ tag }: TagProps) => {
-  const { selectedTags, setSelectedTags } = useContext(TagContext);
+  const selectedTags = useSelector((state: RootState) => state.tags);
+  const dispatch = useDispatch();
   const location = useLocation();
 
   return (
@@ -43,7 +45,8 @@ const Tag = ({ tag }: TagProps) => {
         if (location.pathname === '/') {
           event.preventDefault();
         }
-        setSelectedTags(tag);
+        // setSelectedTags(tag);
+        dispatch(selectTag(tag));
       }}
     >
       {tag}

--- a/src/features/tags/tagsSlice.ts
+++ b/src/features/tags/tagsSlice.ts
@@ -1,0 +1,27 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+type TagsState = string[];
+
+const tagsSlice = createSlice({
+  name: 'tags',
+  initialState: ['All'] as TagsState,
+  reducers: {
+    selectTag: (state, action: PayloadAction<string>) => {
+      if (action.payload === 'All') {
+        return ['All'];
+      }
+      if (state.includes(action.payload)) {
+        const newTags = state.filter(tag => tag !== action.payload);
+        return newTags.length ? newTags : ['All'];
+      }
+      return state.includes('All')
+        ? [action.payload]
+        : [...state, action.payload];
+    },
+    resetTags: () => ['All']
+  }
+});
+
+export const { selectTag, resetTags } = tagsSlice.actions;
+
+export default tagsSlice.reducer;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,18 +1,19 @@
 import { css } from '@emotion/react';
+import { RootState } from 'app/store';
 import { Link, graphql, PageProps } from 'gatsby';
-import { useMemo, useContext } from 'react';
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 
 import Bio from 'components/bio';
 import Layout from 'components/layout';
 import Seo from 'components/seo';
 import Tag from 'components/tags';
-import TagContext from 'context/TagContext';
 import { tagListStyle } from 'styles/style';
 
 const BlogIndex = ({ data, location }: PageProps<Queries.BlogIndexQuery>) => {
   const siteTitle = data.site?.siteMetadata?.title || `Title`;
   const posts = data.allMarkdownRemark.nodes;
-  const { selectedTags } = useContext(TagContext);
+  const selectedTags = useSelector((state: RootState) => state.tags);
 
   const filteredPosts = useMemo(() => {
     if (!selectedTags.length || selectedTags.includes('All')) {


### PR DESCRIPTION
### 작업내용

1. redux toolkit 관련 패키지인 @reduxjs/toolkit react-redux 를 설치했습니다.
2. 전체 store와 rootReducer을 관리하는 app 폴더와 기능별로 폴더를 분리하기 위한 features 폴더를 src/ 아래에 추가했습니다.
3. contextAPI로 구현된 태그 기능을 redux toolkit을 사용해서 구현했습니다.
   -> [rootReducer.ts](https://github.com/WonhyeongLee/Wonhyeong.develop.log/blob/refactor/issue-15-redux-toolkit/src/app/rootReducer.ts) / [store.ts](https://github.com/WonhyeongLee/Wonhyeong.develop.log/blob/refactor/issue-15-redux-toolkit/src/app/store.ts) / [tagsSlice.ts](https://github.com/WonhyeongLee/Wonhyeong.develop.log/blob/refactor/issue-15-redux-toolkit/src/features/tags/tagsSlice.ts)
4. gatsby-browser.tsx, gatsby-ssr.tsx에 provider을 변경했습니다.
5. 태그 기능을 사용하고 있는 tags, pages/index.ts 파일에서 해당 부분을 바뀐 코드로 변경해줬습니다.

### 관련 이슈
#15 
