### PR TITLE
design: 태그 리스트 간격 수정, 폰트 변경, 하단 Nav 부분 스타일링

### DIFF
--- a/gatsby-browser.tsx
+++ b/gatsby-browser.tsx
@@ -9,10 +9,9 @@ import store from './src/app/store';
 import { globalStyles } from './src/styles/globalStyles';
 import { globalVariables } from './src/styles/globalVariables';
 // custom typefaces
-import '@fontsource/montserrat';
-import '@fontsource/montserrat/700.css';
-import '@fontsource/montserrat/900.css';
-import '@fontsource/merriweather';
+import '@fontsource/noto-sans-kr';
+import '@fontsource/noto-sans-kr/700.css';
+import '@fontsource/noto-sans-kr/900.css';
 // custom CSS styles
 import './src/style.css';
 // Highlighting for code blocks

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "@fontsource/merriweather": "^5.0.3",
         "@fontsource/montserrat": "^5.0.3",
+        "@fontsource/noto-sans-kr": "^5.0.5",
         "@fortawesome/fontawesome-svg-core": "^6.4.0",
         "@fortawesome/free-brands-svg-icons": "^6.4.0",
         "@fortawesome/free-regular-svg-icons": "^6.4.0",
@@ -2294,6 +2295,11 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@fontsource/montserrat/-/montserrat-5.0.3.tgz",
       "integrity": "sha512-HxbmY6UeFmwwaqLg3vdkre2U0YgACood2cllKC2ohJdwP9YAieJltodOAcgY0lwvpTAeadW8FlvKFWQIPcS4cg=="
+    },
+    "node_modules/@fontsource/noto-sans-kr": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@fontsource/noto-sans-kr/-/noto-sans-kr-5.0.5.tgz",
+      "integrity": "sha512-lWiNL/up3HDm3Qi04MToLwyGji03lcpA9dTfID9Dl41tGbHsA1xZ+9SnPl+DKo+ZI9njQdZvjDQOONwQ+sPiGQ=="
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
       "version": "6.4.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@fontsource/merriweather": "^5.0.3",
     "@fontsource/montserrat": "^5.0.3",
+    "@fontsource/noto-sans-kr": "^5.0.5",
     "@fortawesome/fontawesome-svg-core": "^6.4.0",
     "@fortawesome/free-brands-svg-icons": "^6.4.0",
     "@fortawesome/free-regular-svg-icons": "^6.4.0",

--- a/src/components/tags.tsx
+++ b/src/components/tags.tsx
@@ -14,7 +14,7 @@ const hoverAndSelectedTagStyle = css`
 
 const tagStyle = css`
   display: inline-block;
-  margin: 0 5px;
+  margin: 5px 5px;
   padding: 5px 10px;
   background-color: #dee2e6;
   font-size: 14px;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,14 +1,13 @@
-import { css } from '@emotion/react';
 import { RootState } from 'app/store';
 import { Link, graphql, PageProps } from 'gatsby';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
+import { postTagsListStyle, postListStyle, footerStyle } from './styles';
 import Bio from 'components/bio';
 import Layout from 'components/layout';
 import Seo from 'components/seo';
 import Tag from 'components/tags';
-import { tagListStyle } from 'styles/style';
 
 const BlogIndex = ({ data, location }: PageProps<Queries.BlogIndexQuery>) => {
   const siteTitle = data.site?.siteMetadata?.title || `Title`;
@@ -47,8 +46,8 @@ const BlogIndex = ({ data, location }: PageProps<Queries.BlogIndexQuery>) => {
           const title = post.frontmatter?.title || post.fields?.slug;
           return (
             <li key={post.fields?.slug}>
-              <article
-                className="post-list-item"
+              <section
+                css={postListStyle}
                 itemScope
                 itemType="http://schema.org/Article"
               >
@@ -69,24 +68,20 @@ const BlogIndex = ({ data, location }: PageProps<Queries.BlogIndexQuery>) => {
                     itemProp="description"
                   />
                 </section>
-                <footer
-                  css={css`
-                    margin-left: -32px;
-                  `}
-                >
+                <footer css={footerStyle}>
                   {post.frontmatter?.tags && (
-                    <ul css={tagListStyle}>
+                    <ul css={postTagsListStyle} role="list">
                       {post.frontmatter.tags
                         .filter((tag): tag is string => tag !== null)
                         .map(tag => (
-                          <li key={tag}>
+                          <li key={tag} role="list">
                             <Tag key={tag} tag={tag} />
                           </li>
                         ))}
                     </ul>
                   )}
                 </footer>
-              </article>
+              </section>
               <hr />
             </li>
           );

--- a/src/pages/styles.ts
+++ b/src/pages/styles.ts
@@ -10,5 +10,5 @@ export const postListStyle = css`
 `;
 
 export const footerStyle = css`
-  margin-left: -32px;
+  margin-left: -5px;
 `;

--- a/src/pages/styles.ts
+++ b/src/pages/styles.ts
@@ -1,0 +1,14 @@
+import { css } from '@emotion/react';
+
+export const postTagsListStyle = css`
+  display: flex;
+  margin: var(--spacing-4) 0;
+`;
+
+export const postListStyle = css`
+  margin-top: var(--spacing-2);
+`;
+
+export const footerStyle = css`
+  margin-left: -32px;
+`;

--- a/src/styles/globalStyles.ts
+++ b/src/styles/globalStyles.ts
@@ -163,16 +163,6 @@ export const globalStyles = css`
     padding: var(--spacing-0);
   }
 
-  ul,
-  ol {
-    margin-left: var(--spacing-0);
-    margin-right: var(--spacing-0);
-    padding: var(--spacing-0);
-    /* margin-bottom: var(--spacing-8); */
-    list-style-position: outside;
-    list-style-image: none;
-  }
-
   /* ul li,
 ol li {
   padding-left: var(--spacing-0);
@@ -238,7 +228,7 @@ ol li {
   ol,
   ul {
     margin: 0;
-    padding-left: 1.5rem;
+    padding: 0;
   }
   a {
     color: inherit;

--- a/src/styles/globalVariables.ts
+++ b/src/styles/globalVariables.ts
@@ -28,11 +28,11 @@ export const globalVariables = css`
     --spacing-20: 5rem;
     --spacing-24: 6rem;
     --spacing-32: 8rem;
-    --fontFamily-sans: 'Montserrat', system-ui, -apple-system,
+    --fontFamily-sans: 'Noto Sans KR', system-ui, -apple-system,
       BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
       'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
       'Segoe UI Symbol', 'Noto Color Emoji';
-    --fontFamily-serif: 'Merriweather', 'Georgia', Cambria, 'Times New Roman',
+    --fontFamily-serif: 'Noto Sans KR', 'Georgia', Cambria, 'Times New Roman',
       Times, serif;
     --font-body: var(--fontFamily-serif);
     --font-heading: var(--fontFamily-sans);

--- a/src/styles/style.ts
+++ b/src/styles/style.ts
@@ -85,20 +85,12 @@ export const socialIconStyle = css`
     transition: color 0.3s;
   }
 `;
-// pages Style
-export const tagListStyle = css`
-  display: flex;
-  flex-wrap: wrap;
-  list-style: none;
-  margin-top: var(--spacing-2);
-`;
 // layout의 tagListStyle
-export const tagsListStyle = state => css`
+export const tagsListStyle = (state: string) => css`
   ${globalContentsStyle}
   position: relative;
   flex-wrap: wrap;
   background: #f4f4f4;
-  margin: 20px 0;
   padding: 10px 20px;
   visibility: hidden;
   opacity: 0;

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -1,5 +1,6 @@
 import { Link, graphql, PageProps } from 'gatsby';
 
+import { blogPostNavStyle, navBoxStyle } from './styles';
 import Bio from '../components/bio';
 import Layout from '../components/layout';
 import Seo from '../components/seo';
@@ -38,27 +39,26 @@ const BlogPostTemplate = ({
           <Bio />
         </footer>
       </article>
-      <nav className="blog-post-nav">
-        <ul
-          style={{
-            display: `flex`,
-            flexWrap: `wrap`,
-            justifyContent: `space-between`,
-            listStyle: `none`
-          }}
-        >
+      <nav css={blogPostNavStyle}>
+        <ul>
           <li>
             {data.previous && (
-              <Link to={data.previous?.fields?.slug || ''} rel="prev">
-                ← {data.previous?.frontmatter?.title}
-              </Link>
+              <div css={navBoxStyle}>
+                <span>이전 게시물</span>
+                <Link to={data.previous?.fields?.slug || ''} rel="prev">
+                  ← {data.previous?.frontmatter?.title}
+                </Link>
+              </div>
             )}
           </li>
           <li>
             {data.next && (
-              <Link to={data.next?.fields?.slug || ''} rel="next">
-                {data.next?.frontmatter?.title} →
-              </Link>
+              <div css={navBoxStyle}>
+                <span>다음 게시물</span>
+                <Link to={data.next?.fields?.slug || ''} rel="next">
+                  {data.next?.frontmatter?.title} →
+                </Link>
+              </div>
             )}
           </li>
         </ul>

--- a/src/templates/styles.ts
+++ b/src/templates/styles.ts
@@ -1,0 +1,26 @@
+import { css } from '@emotion/react';
+
+export const blogPostNavStyle = css`
+  font-size: var(--fontSize-2);
+  margin-top: var(--spacing-8);
+  > ul {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    list-style: none;
+  }
+`;
+
+export const navBoxStyle = css`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 20px 16px;
+  min-width: 250px;
+  font-size: var(--fontSize-1);
+  border-radius: 5px;
+  background-color: rgba(0, 0, 0, 0.06);
+  color: rgb(25, 25, 25);
+  cursor: pointer;
+  transition: background-color 0.3s ease 0s;
+`;


### PR DESCRIPTION
## 작업 내용

1. 폰트를 mono-sans-kr로 변경했습니다.
2. 태그 리스트에서 태그가 많아질 때 태그 위아래 간격이 없어서 붙어있던 부분 수정했습니다.
3. 하단 Nav (이전 페이지, 다음 페이지) 스타일링 안 돼있던 부분 수정했습니다.
4. 한 CSS 파일에서 꺼내쓰던 방식에서 컴포넌트 별 스타일 파일을 생성하는 방법으로 바꾸고 있습니다. 
5. 처음 블로그 탬플릿에서 사용하던 전역설정 중에 ol, ul, li 부분 설정이 곂쳐서 margin, padding 이 사용하는 부분마다 수치를 설정하다보니 코드가 더러워져서 일단 전역 설정을 margin과 padding 에 대해 0으로 변경해줬습니다.

## 관련 이슈

#19 

## 적용 화면

![태그리스트 간격조정과 폰트변경](https://github.com/WonhyeongLee/Wonhyeong.develop.log/assets/54429762/27c05421-ab18-4a1f-ac88-0b13513f6fa5)

![하단 nav 부분 스타일링](https://github.com/WonhyeongLee/Wonhyeong.develop.log/assets/54429762/0550aa7a-d8d0-48e0-8f50-27923826f16b)

